### PR TITLE
JSON number as a double QVariant

### DIFF
--- a/json.cpp
+++ b/json.cpp
@@ -430,7 +430,7 @@ QVariant Json::parseNumber(const QString &json, int &index)
 	
 	index = lastIndex + 1;
 
-	return QVariant(numberStr);
+	return QVariant(numberStr.toDouble(NULL));
 }
 
 /**


### PR DESCRIPTION
Hello!
According this wiki page (http://en.wikipedia.org/wiki/JSON) an JSON number should be represented as a double precision floating-point format (not exactly specified but in practice).
What do you think?
