### PR TITLE
Corrected serialization of long values.

### DIFF
--- a/json.cpp
+++ b/json.cpp
@@ -177,7 +177,7 @@ QByteArray Json::serialize(const QVariant &data, bool &success)
         }
         else if (data.canConvert<long>())
         {
-                str = sanitizeString(QString::number(data.value<long>())).toUtf8();
+                str = QString::number(data.value<long>()).toUtf8();
         }
         else if (data.canConvert<QString>()) // can value be converted to string?
         {


### PR DESCRIPTION
Shouldn't be calling sanatize string when serializing long values. It adds quotes around the number thus implying it's a string. There shouldn't be anything to santizes anyway.
