### PR TITLE
Qt5 compatibility fix

### DIFF
--- a/json.cpp
+++ b/json.cpp
@@ -594,7 +594,7 @@ static int nextToken(const QString &json, int &index)
 
         QChar c = json[index];
         index++;
-        switch(c.toAscii())
+        switch(c.toLatin1())
         {
                 case '{': return JsonTokenCurlyOpen;
                 case '}': return JsonTokenCurlyClose;


### PR DESCRIPTION
QString::toAscii() method is removed in Qt5
