### PR TITLE
Trying to serialize NaN, negative infinity and positive infinity does no longer work because they are not part of JSON.

### DIFF
--- a/json.cpp
+++ b/json.cpp
@@ -155,10 +155,15 @@ QByteArray serialize(const QVariant &data, bool &success)
         }
         else if(data.type() == QVariant::Double) // double?
         {
-                str = QByteArray::number(data.toDouble(), 'g', 20);
-                if(!str.contains(".") && ! str.contains("e"))
-                {
-                        str += ".0";
+                double value = data.toDouble();
+                if ((value - value) == 0.0) {
+                        str = QByteArray::number(value, 'g', 20);
+                        if(!str.contains(".") && ! str.contains("e"))
+                        {
+                                str += ".0";
+                        }
+                } else {
+                    success = false;
                 }
         }
         else if (data.type() == QVariant::Bool) // boolean value?


### PR DESCRIPTION
Serializing NaN and infinity was possible until now. However, parsing of these values did not work. Also, the JSON spec does not allow for these values. The code now tests for these values and sets 'successful' to false.

Best regards
Stephen Kockentiedt
