### PR TITLE
Added QStringList inclusion.

### DIFF
--- a/json.cpp
+++ b/json.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <QDateTime>
+#include <QStringList>
 #include "json.h"
 
 namespace QtJson {


### PR DESCRIPTION
This should fix problems with compilation on OS/2 + Qt4.

[ 34%] Building CXX object CMakeFiles/rssguard.dir/src/gui/dialogs/formdatabasecleanup.cpp.obj
H:/rssguard/src/qt-json/json.cpp: In function 'QVariant QtJson::clone(const QVariant&)':
H:/rssguard/src/qt-json/json.cpp:120:37: error: invalid use of incomplete type 'class QStringList'
      cloneList(v, data.toStringList());
                                     ^
In file included from C:/usr/include/QtCore/qdatetime.h:45:0,
                 from C:/usr/include/QtCore/QDateTime:1,
                 from H:/rssguard/src/qt-json/json.cpp:23:
C:/usr/include/QtCore/qstring.h:94:7: error: forward declaration of 'class QStringList'
 class QStringList;
       ^
CMakeFiles/rssguard.dir/build.make:714: recipe for target 'CMakeFiles/rssguard.dir/src/qt-json/json.cpp.obj' failed
make[2]: *** [CMakeFiles/rssguard.dir/src/qt-json/json.cpp.obj] Error 1
make[2]: *** Waiting for unfinished jobs....
CMakeFiles/Makefile2:128: recipe for target 'CMakeFiles/rssguard.dir/all' failed
make[1]: *** [CMakeFiles/rssguard.dir/all] Error 2
Makefile:146: recipe for target 'all' failed
make: *** [all] Error 2