### PR TITLE
Add QtJson::Object class implementation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Eeli Reilin <gaudecker@fea.st>
 Luis Gustavo S. Barreto <gustavosbarreto@gmail.com>
 Stephen Kockentiedt <Stephen@Kockentiedt.name>
+Ilya V. Matveychikov <matvejchikov@gmail.com>

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -54,6 +54,29 @@ void testClone()
         qFatal("An error occured while cloning");
 }
 
+void testObj()
+{
+    QtJson::Object json;
+
+    // compile-only test, needs to be improved
+
+    json["int"] = 0;
+
+    json["str"]["a"] = QString("StringA");
+    json["str"]["b"] = QString("StringB");
+    json["str"]["c"] = QString("StringC");
+
+    json["obj"]["QVariant"] = QVariant();
+    json["obj"]["QVariantMap"] = QVariantMap();
+    json["obj"]["QVariantHash"] = QVariantHash();
+
+    qDebug() << "QtJson::Object [1]" << QtJson::serialize(json);
+
+    json.remove("obj");
+
+    qDebug() << "QtJson::Object [2]" << QtJson::serialize(json);
+}
+
 int main(int argc, char **argv) {
     QString json = readFile("example.json");
     if (json.isEmpty()) {
@@ -80,6 +103,7 @@ int main(int argc, char **argv) {
     printJson(result);
 
     testClone();
+    testObj();
 
     return 0;
 }

--- a/json.h
+++ b/json.h
@@ -129,6 +129,50 @@ namespace QtJson {
      */
     QString getDateTimeFormat();
     QString getDateFormat();
+
+    /**
+     * QVariant based Json object
+     */
+    class Object : public QVariant {
+        template<typename T>
+        Object& insertKey(Object* ptr, const QString& key) {
+            T* p = (T*)ptr->data();
+            if (!p->contains(key)) p->insert(key, QVariant());
+            return *reinterpret_cast<Object*>(&p->operator[](key));
+        }
+        template<typename T>
+        void removeKey(Object *ptr, const QString& key) {
+            T* p = (T*)ptr->data();
+            p->remove(key);
+        }
+    public:
+        Object() : QVariant() {}
+        Object(const Object& ref) : QVariant(ref) {}
+
+        Object& operator=(const QVariant& rhs) {
+            setValue(rhs);
+            return *this;
+        }
+        Object& operator[](const QString& key) {
+            if (type() == QVariant::Map)
+                return insertKey<QVariantMap>(this, key);
+            else if (type() == QVariant::Hash)
+                return insertKey<QVariantHash>(this, key);
+
+            setValue(QVariantMap());
+
+            return insertKey<QVariantMap>(this, key);
+        }
+        const Object& operator[](const QString& key) const {
+            return const_cast<Object*>(this)->operator[](key);
+        }
+        void remove(const QString& key) {
+            if (type() == QVariant::Map)
+                removeKey<QVariantMap>(this, key);
+            else if (type() == QVariant::Hash)
+                removeKey<QVariantHash>(this, key);
+        }
+    };
 }
 
 #endif //JSON_H


### PR DESCRIPTION
Hello,

It's useful to me to use json object with `json[key] = value` semantics. This patch set adds `QVariant`-based `QtJson::Object` class that implements such an ability. Now it's possible to use the following:

~~~
QtJson::Object json;
json["a"] = 0;
json["b"]["c"] = 1;
json["b"]["d"] = 2;
json["b"]["e"]["f"] = QString("hello");
~~~