### PR TITLE
Added Builders + Pretty-print serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,30 @@ The byte array 'data' contains valid JSON data:
 }
 ```
 
+#### Serializing JSON pretty-print ####
+By default, the serialization will create a _minified_ version, like following:
+
+```json
+{"name":"Luis Gustavo","age":22}
+```
+
+If you are debugging or logging, you may prefer to enable **pretty-print** mode globally, before serialize:
+
+```cpp
+QtJson::setPrettySerialize(true);
+
+QByteArray data = QtJson::serialize(contributor);
+// ...
+QByteArray data = QtJson::serialize(other_contributor);
+```
+
+Obviously, you can disable it with:
+```cpp
+QtJson::setPrettySerialize(false);
+```
+
+---
+
 After creating the QVariantMap, you can create a [QVariantList/JsonArray][varlist] and append the QVariantMaps. 
 
 ```cpp    
@@ -128,6 +152,58 @@ This way you create a nested structure:
 ```
 
 If you continue this process recursively, you nest more levels into the JSON structure.
+
+
+#### Using Builders ####
+
+For semplicity you can use **builders**, if you prefer.
+
+For example, create a `JsonObject`:
+
+```cpp
+QtJson::JsonObject json = QtJson::objectBuilder()
+    ->set("field_1", 10)
+    ->set("field_2", "A string")
+    ->set("field_3", true)
+    ->set("field_4", QtJson::objectBuilder()
+        ->set("sub_field_1", 10.4)
+        ->set("sub_field_n", "Another string")
+    )
+    ->create();
+```
+
+Or create a `JsonArray`:
+
+```cpp
+QtJson::JsonArray json = QtJson::arrayBuilder()
+    ->add(5)
+    ->add(90.2)
+    ->add(true)
+    ->add("anything else")
+    ->create();
+```
+
+Take a look at this example that rewrite the previous one:
+
+```cpp
+QtJson::JsonObject obj = QtJson::objectBuilder()
+    ->set("friends", QtJson::arrayBuilder()
+        ->add(QtJson::objectBuilder()
+            ->set("id", 1)
+            ->set("name", "Mackenzie Hamphrey")
+        )
+        ->add(QtJson::objectBuilder()
+            ->set("id", 2)
+            ->set("name", "Melanie Molligan")
+        )
+        ->add(QtJson::objectBuilder()
+            ->set("id", 3)
+            ->set("name", "Sydney Calhoun")
+        )
+    )
+    ->create();
+```
+
 
 ### 3. CONTRIBUTING ###
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ If you continue this process recursively, you nest more levels into the JSON str
 
 #### Using Builders ####
 
-For semplicity you can use **builders**, if you prefer.
+For simplicity you can use **builders**, if you prefer.
 
 For example, create a `JsonObject`:
 

--- a/json.h
+++ b/json.h
@@ -25,6 +25,7 @@
 
 #include <QVariant>
 #include <QString>
+#include <QQueue>
 
 
 /**
@@ -93,7 +94,7 @@ namespace QtJson {
      *
      * \return QByteArray Textual JSON representation in UTF-8
      */
-    QByteArray serialize(const QVariant &data, bool &success);
+    QByteArray serialize(const QVariant &data, bool &success, int _level = 0);
 
     /**
      * This method generates a textual JSON representation
@@ -112,7 +113,7 @@ namespace QtJson {
      *
      * \return QString Textual JSON representation
      */
-    QString serializeStr(const QVariant &data, bool &success);
+    QString serializeStr(const QVariant &data, bool &success, int _level = 0);
 
     /**
      * This method sets date(time) format to be used for QDateTime::toString
@@ -129,6 +130,21 @@ namespace QtJson {
      */
     QString getDateTimeFormat();
     QString getDateFormat();
+
+    /**
+     * @brief setPrettySerialize enable/disabled pretty-print when serialize() a json
+     * @param enabled
+     */
+    void setPrettySerialize(bool enabled);
+
+    /**
+     * @brief isPrettySerialize check if is enabled pretty-print when serialize() a json
+     * @return
+     */
+    bool isPrettySerialize();
+
+
+
 
     /**
      * QVariant based Json object
@@ -176,6 +192,74 @@ namespace QtJson {
                 removeKey<QVariantHash>(this, key);
         }
     };
+
+
+    class BuilderJsonArray;
+
+    /**
+     * @brief The BuilderJsonObject class
+     */
+    class BuilderJsonObject {
+
+        public:
+            BuilderJsonObject();
+            BuilderJsonObject(JsonObject &json);
+
+            BuilderJsonObject *set(const QString &key, const QVariant &value);
+            BuilderJsonObject *set(const QString &key, BuilderJsonObject *builder);
+            BuilderJsonObject *set(const QString &key, BuilderJsonArray *builder);
+            JsonObject create();
+
+        private:
+            static QQueue<BuilderJsonObject *> created_list;
+
+            JsonObject obj;
+    };
+
+    /**
+     * @brief The BuilderJsonArray class
+     */
+    class BuilderJsonArray {
+
+        public:
+            BuilderJsonArray();
+            BuilderJsonArray(JsonArray &json);
+
+            BuilderJsonArray *add(const QVariant &element);
+            BuilderJsonArray *add(BuilderJsonObject *builder);
+            BuilderJsonArray *add(BuilderJsonArray *builder);
+            JsonArray create();
+
+        private:
+            static QQueue<BuilderJsonArray *> created_list;
+
+            JsonArray array;
+    };
+
+
+    /**
+     * @brief Create a BuilderJsonObject
+     * @return
+     */
+    BuilderJsonObject *objectBuilder();
+
+    /**
+     * @brief Create a BuilderJsonObject starting from copy of another json
+     * @return
+     */
+    BuilderJsonObject *objectBuilder(JsonObject &json);
+
+    /**
+     * @brief Create a BuilderJsonArray
+     * @return
+     */
+    BuilderJsonArray *arrayBuilder();
+
+    /**
+     * @brief Create a BuilderJsonArray starting from copy of another json
+     * @return
+     */
+    BuilderJsonArray *arrayBuilder(JsonArray &json);
 }
 
 #endif //JSON_H


### PR DESCRIPTION
#### Using Builders ####

For simplicity you can use **builders**, if you prefer.

For example, create a `JsonObject`:

```cpp
QtJson::JsonObject json = QtJson::objectBuilder()
    ->set("field_1", 10)
    ->set("field_2", "A string")
    ->set("field_3", true)
    ->set("field_4", QtJson::objectBuilder()
        ->set("sub_field_1", 10.4)
        ->set("sub_field_n", "Another string")
    )
    ->create();
```

Or create a `JsonArray`:

```cpp
QtJson::JsonArray json = QtJson::arrayBuilder()
    ->add(5)
    ->add(90.2)
    ->add(true)
    ->add("anything else")
    ->create();
```

Take a look at this example that rewrite the previous one:

```cpp
QtJson::JsonObject obj = QtJson::objectBuilder()
    ->set("friends", QtJson::arrayBuilder()
        ->add(QtJson::objectBuilder()
            ->set("id", 1)
            ->set("name", "Mackenzie Hamphrey")
        )
        ->add(QtJson::objectBuilder()
            ->set("id", 2)
            ->set("name", "Melanie Molligan")
        )
        ->add(QtJson::objectBuilder()
            ->set("id", 3)
            ->set("name", "Sydney Calhoun")
        )
    )
    ->create();
```

---

#### Serializing JSON pretty-print ####
By default, the serialization will create a _minified_ version, like following:

```json
{"name":"Luis Gustavo","age":22}
```

If you are debugging or logging, you may prefer to enable **pretty-print** mode globally, before serialize:

```cpp
QtJson::setPrettySerialize(true);

QByteArray data = QtJson::serialize(contributor);
// ...
QByteArray data = QtJson::serialize(other_contributor);
```

Obviously, you can disable it with:
```cpp
QtJson::setPrettySerialize(false);
```